### PR TITLE
miniFixes

### DIFF
--- a/frontend/src/pages/Budgets.jsx
+++ b/frontend/src/pages/Budgets.jsx
@@ -119,7 +119,8 @@ const Budgets = () => {
     setFormData({
       amount: budget.amount ?? "",
       description: budget.description ?? "",
-      category_id: budget.category_id ?? "",
+      category_id:
+        budget.category?._id || budget.category_id || budget.category || "",
       date: budget.date ?? "",
       period: budget.period ?? "monthly",
       start_date: budget.startDate

--- a/frontend/src/pages/Transactions.jsx
+++ b/frontend/src/pages/Transactions.jsx
@@ -72,7 +72,7 @@ const Transactions = () => {
     setFormData({
       amount: transaction.amount,
       description: transaction.description,
-      category_id: transaction.category_id,
+      category_id: transaction.category?._id || transaction.category_id || "",
       date: transaction.date
         ? new Date(transaction.date).toISOString().split("T")[0]
         : new Date().toISOString().split("T")[0],


### PR DESCRIPTION
This pull request includes updates to improve how `category_id` is assigned in the `Budgets` and `Transactions` components. The changes ensure compatibility with different formats of category data and add robustness when handling optional fields.

### Updates to `category_id` assignment logic:

* [`frontend/src/pages/Budgets.jsx`](diffhunk://#diff-b50d669ed183e9be0259ea8a1c9bf03fdcc5cd22a0a6b809b85ee873bfa22269L122-R123): Updated the `category_id` assignment to handle cases where `budget.category` is an object with an `_id` property, falling back to other possible formats (`budget.category_id` or `budget.category`).

* [`frontend/src/pages/Transactions.jsx`](diffhunk://#diff-f81f9cb644346eb445de68bec09d6a1d218fc520dd29d9b8535460c276c2ae92L75-R75): Modified the `category_id` assignment to prioritize `transaction.category?._id` when available, with a fallback to `transaction.category_id`.